### PR TITLE
[stable/redis] make persistent volume mountPath configurable

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,6 +1,6 @@
 name: redis
 version: 0.10.1
-appVersion: 3.2.9
+appVersion: 3.2.10
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:
 - redis

--- a/stable/redis/README.md
+++ b/stable/redis/README.md
@@ -55,6 +55,7 @@ The following tables lists the configurable parameters of the Redis chart and th
 | `persistence.storageClass` | Storage class of backing PVC          | `generic`                                                 |
 | `persistence.accessMode`   | Use volume as ReadOnly or ReadWrite   | `ReadWriteOnce`                                           |
 | `persistence.size`         | Size of data volume                   | `8Gi`                                                     |
+| `persistence.mountPath`    | Path to mount volume                  | `/bitnami/redis`                                          |
 | `resources`                | CPU/Memory resource requests/limits   | Memory: `256Mi`, CPU: `100m`                              |
 | `metrics.enabled`          | Start a side-car prometheus exporter  | `false`                                                   |
 | `metrics.image`            | Exporter image                        | `oliver006/redis_exporter`                                |

--- a/stable/redis/templates/deployment.yaml
+++ b/stable/redis/templates/deployment.yaml
@@ -61,7 +61,7 @@ spec:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
         - name: redis-data
-          mountPath: /bitnami/redis
+          mountPath: {{ .Values.persistence.mountPath }}
 {{- if .Values.metrics.enabled }}
       - name: metrics
         image: "{{ .Values.metrics.image }}:{{ .Values.metrics.imageTag }}"

--- a/stable/redis/values.yaml
+++ b/stable/redis/values.yaml
@@ -31,7 +31,7 @@ args:
 ##
 persistence:
   enabled: true
-
+  mountPath: /bitnami/redis 
   ## A manually managed Persistent Volume and Claim
   ## Requires persistence.enabled: true
   ## If defined, PVC must be created manually before volume will be bound


### PR DESCRIPTION
The purpose of this PR is to allow the redis chart to use the docker library redis image with persistent storage enabled. As of now, you must use the bitnami image if you want persistent storage (the redis image expects data to be in  /data, the bitnami image expects it to be /bitnami/redis). 

